### PR TITLE
Allow arrow keys to restart after game over

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ desktop and mobile devices.
 
 ### Controls
 
-- **Keyboard:** Use the arrow keys to move the snake.
+- **Keyboard:** Use the arrow keys to move the snake. After a game over you can
+  press any arrow key to restart immediately.
 - **Mobile:** Use the on-screen arrow buttons to change direction.
 
 ## Customization

--- a/script.js
+++ b/script.js
@@ -73,15 +73,19 @@ function restartGame() {
 window.addEventListener('keydown', e => {
     switch (e.key) {
         case 'ArrowUp':
+            if (gameOver) restartGame();
             changeDirection({x:0, y:-1});
             break;
         case 'ArrowDown':
+            if (gameOver) restartGame();
             changeDirection({x:0, y:1});
             break;
         case 'ArrowLeft':
+            if (gameOver) restartGame();
             changeDirection({x:-1, y:0});
             break;
         case 'ArrowRight':
+            if (gameOver) restartGame();
             changeDirection({x:1, y:0});
             break;
     }


### PR DESCRIPTION
## Summary
- allow arrow key presses to restart the game when game over
- document this restart shortcut in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684247463f7c832ca95999d8b19a0acd